### PR TITLE
apply magnet during the drag operation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,6 +130,14 @@ function updateData(chartInstance, callback) {
         data = calcPosition(e, chartInstance, curDatasetIndex, curIndex, data)
       }
 
+      const dragOptions = chartInstance.options.dragOptions
+      if (dragOptions && dragOptions.magnet) {
+        const magnet = dragOptions.magnet
+        if (magnet.applyDuringDrag === true && magnet.to && typeof magnet.to === 'function') {
+            data = magnet.to(data)
+        }
+      }
+
       if (typeof callback === 'function') {
         if (callback(e, curDatasetIndex, curIndex, data) !== false) {
           chartInstance.data.datasets[curDatasetIndex].data[curIndex] = data


### PR DESCRIPTION
Would it be possible to add something like this so while dragging the bars they snap the the magnet values instead of resizing to the magnet values in dragEnd ?

If you think this would slow down drag events too much could the callback event be modified so the callback can modify the value?