### PR TITLE
fix: apply magnet even if `onDragEnd` is not provided; fixes 163

### DIFF
--- a/src/util/dragEndCallback.ts
+++ b/src/util/dragEndCallback.ts
@@ -33,12 +33,15 @@ export function dragEndCallback<TType extends ChartType>(
 		chartInstance.update("none");
 	}
 
-	if (typeof callback === "function" && state.element) {
-		const datasetIndex = state.element.datasetIndex;
-		const index = state.element.index;
+	if (!state.element) {
+		return;
+	}
 
-		let value = applyMagnet(chartInstance, datasetIndex, index);
+	const datasetIndex = state.element.datasetIndex;
+	const index = state.element.index;
+	const value = applyMagnet(chartInstance, datasetIndex, index);
 
+	if (typeof callback === "function") {
 		return callback(event, datasetIndex, index, value);
 	}
 }


### PR DESCRIPTION
## Describe your changes

This PR moves out magnet invocation from the conditional block so as to apply it regardless of whether `dragEndCallback` is provided or not.

## Linked issues (if any)

- #163 
- #50 (very old PR that does not match the current code state, thus has been resolved here)